### PR TITLE
FIX: Upgrade log4j to 2.15.0 to mitigate vulnerability. Fixes #139

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,8 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+		 <log4j2.version>2.15.0</log4j2.version>
 	</properties>
-
-
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
References : https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot

To disable JDNI, I added `-Dspring.jndi.ignore=true` in the VM arguments

Reference:
https://github.com/pinpoint-apm/pinpoint/issues/8489#issuecomment-993105572